### PR TITLE
Modified AugmentEnvironment to accept a collection of key value pairs

### DIFF
--- a/testing.go
+++ b/testing.go
@@ -125,7 +125,7 @@ func (t *Tester) TestRequestWithName(name string, tst *testing.T, handler func(*
 }
 
 // AugmentEnvironment of the Tester with one more key value pair. These are set to text with no description and as enabled.
-func (t *Tester) AugmentEnvironment(values map[string]string) *Tester {
+func (t *Tester) AugmentEnvironment(values map[string]string) {
 	for k, v := range values {
 		newValue := postman.Variable{
 			Key:         k,
@@ -137,7 +137,7 @@ func (t *Tester) AugmentEnvironment(values map[string]string) *Tester {
 		t.Environment.Values = append(t.Environment.Values, newValue)
 	}
 
-	return t
+	return
 }
 
 func makeRequest(client *http.Client, req *http.Request) (*postman.Response, error) {

--- a/testing.go
+++ b/testing.go
@@ -124,18 +124,20 @@ func (t *Tester) TestRequestWithName(name string, tst *testing.T, handler func(*
 	return nil
 }
 
-// AugmentEnvironment of the Tester with one more key value pair
-func (t *Tester) AugmentEnvironment(key string, value string, valueType string, description string, enabled bool) (*Tester, error) {
-	newValue := postman.Variable{
-		Key:         key,
-		Value:       value,
-		Type:        valueType,
-		Description: description,
-		Enabled:     enabled,
+// AugmentEnvironment of the Tester with one more key value pair. These are set to text with no description and as enabled.
+func (t *Tester) AugmentEnvironment(values map[string]string) *Tester {
+	for k, v := range values {
+		newValue := postman.Variable{
+			Key:         k,
+			Value:       v,
+			Type:        "text",
+			Description: "",
+			Enabled:     true,
+		}
+		t.Environment.Values = append(t.Environment.Values, newValue)
 	}
-	t.Environment.Values = append(t.Environment.Values, newValue)
 
-	return t, nil
+	return t
 }
 
 func makeRequest(client *http.Client, req *http.Request) (*postman.Response, error) {


### PR DESCRIPTION
Modifies the Augment Environment function to accept a collection of key value pairs per issue #275 in GitLab.

Furthermore it cannot error, and so the error return was removed.